### PR TITLE
nv_groupe: Use max(id) instead of len(channels)

### DIFF
--- a/messenger.py
+++ b/messenger.py
@@ -58,7 +58,7 @@ def id_to_name2(id):
 print(id_to_name(1))
 
 def nv_groupe(name, member_ids):
-    new_channel_id = len(server['channels']) + 1
+    new_channel_id = max(channel['id'] for channel in server['channels']) + 1
     new_channel = {"id": new_channel_id, "name": name, "member_id": member_ids}
     server['channels'].append(new_channel)
     print(f"\nNouveau canal ajouté : {new_channel}")


### PR DESCRIPTION
Cette _pull request_ est un correctif de la fonction `nv_groupe`. Pour générer l'identifiant du nouveau groupe, on se base sur les identifiants des groupes existant et non sur le nombre de groupe.
Cette modification permet de s'assurer que les identifiants de groupe sont bien uniques.